### PR TITLE
Support latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,9 @@ jobs:
       # Test built action itself
       - uses: ./dist/
         with:
-          geckodriver-version: "0.28.0"
+          geckodriver-version: "0.26.0"
+      - run: geckodriver --version
+      - uses: ./dist/
       - run: geckodriver --version
 
   deploy:
@@ -86,5 +88,7 @@ jobs:
     steps:
       - uses: ueokande/setup-geckodriver@latest
         with:
-          geckodriver-version: "0.28.0"
+          geckodriver-version: "0.26.0"
+      - run: geckodriver --version
+      - uses: ueokande/setup-geckodriver@latest
       - run: geckodriver --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 name: 'build-test'
 on:
-  pull_request:
   push:
 
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Install and setup a specific version of Geckodriver'
 author: "Shin'ya Ueoka"
 inputs:
   geckodriver-version:
-    description: 'The Geckodriver version to install and use.'
+    description: 'The Geckodriver version to install and use. Examples: 0.28.0, latest.'
 
 runs:
   using: 'node12'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,28 @@
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
+import * as httpm from "@actions/http-client";
 import { getPlatform, Platform } from "./platform";
 import InstallerFactory from "./InstallerFactory";
+
+type GitHubReleaseApiResponse = {
+  tag_name: string;
+};
+
+const getLatestVersion = async (): Promise<string> => {
+  const apiURL = `https://api.github.com/repos/mozilla/geckodriver/releases/latest`;
+  const http = new httpm.HttpClient("setup-geckodrive");
+  const resp = await http.getJson<GitHubReleaseApiResponse>(apiURL);
+  if (resp.statusCode !== httpm.HttpCodes.OK) {
+    throw new Error(
+      `Failed to get latest version: server returns ${resp.statusCode}`
+    );
+  }
+  if (resp.result === null) {
+    throw new Error("Failed to get latest version: server returns empty body");
+  }
+  return resp.result.tag_name.replace("^v", "");
+};
 
 const install = async (
   version: string,
@@ -30,8 +50,11 @@ const install = async (
 
 const run = async (): Promise<void> => {
   try {
-    const version = core.getInput("geckodriver-version") || "latest";
+    let version = core.getInput("geckodriver-version") || "latest";
     const platform = getPlatform();
+    if (version === "latest") {
+      version = await getLatestVersion();
+    }
 
     core.info(`Setup geckodriver ${version}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ const getLatestVersion = async (): Promise<string> => {
   if (resp.result === null) {
     throw new Error("Failed to get latest version: server returns empty body");
   }
-  return resp.result.tag_name.replace("^v", "");
+  return resp.result.tag_name.replace(/^v/, "");
 };
 
 const install = async (


### PR DESCRIPTION
Support `latest` version to download latest geckodriver release.  The action also latest one if `geckodriver-version` is not set.